### PR TITLE
feat: add runtime Docker image + GHCR publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # trying to make owner lowercase so tags are valid for GHCR... hopefully this works
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
       - name: Build (PR) / Build+Push (main) runtime image
         uses: docker/build-push-action@v6
         with:
@@ -31,7 +35,7 @@ jobs:
           file: Dockerfile.runtime
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/autoresume:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/autoresume:main
+            ghcr.io/${{ env.OWNER }}/autoresume:${{ github.sha }}
+            ghcr.io/${{ env.OWNER }}/autoresume:main
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: docker
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (PR) / Build+Push (main) runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.runtime
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/autoresume:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/autoresume:main
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -28,7 +28,7 @@ PY
 # App code
 COPY src ./src
 COPY pyproject.toml ./pyproject.toml
-COPY builder.py pdf_generator.py ./  # makes imports in src/cli.py work
+# no extra COPY needed; imports use src.*
 
 # Default command can be overridden at run time
 CMD ["python", "-m", "src.cli", "--help"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# System basics (slim image)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+# Runtime deps only (no pytest here)
+COPY requirements.txt ./requirements.txt
+RUN python -m pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+# Pull NLTK data so runtime works offline
+RUN python - <<'PY'
+import nltk
+try:
+    nltk.download("punkt", quiet=True)
+except Exception as e:
+    print("NLTK download warning:", e)
+PY
+
+# App code
+COPY src ./src
+COPY pyproject.toml ./pyproject.toml
+COPY builder.py pdf_generator.py ./  # makes imports in src/cli.py work
+
+# Default command can be overridden at run time
+CMD ["python", "-m", "src.cli", "--help"]

--- a/sample_data/minimal.json
+++ b/sample_data/minimal.json
@@ -1,0 +1,16 @@
+{
+  "contact": { "name": "okpede jessica iyitagye", "email": "jessicarh009@gmail.com", "location": "Abuja, Nigeria" },
+  "education": [
+    { "school": "Nile University of Nigeria", "degree": "Information Technology", "dates": "Oct 2024 - Present", "GPA": "4.5", "location": "Abuja, Nigeria" }
+  ],
+  "skills": { "languages": ["Python", "HTML", "CSS", "Java"], "libraries": ["NumPy", "Pandas"] },
+  "experience": [
+    { "title": "Intern web developer", "company": "Gabson Official", "location": "Abuja", "dates": "Aug 2025 – Present", "summary": "Worked with devs to build & manage the company website; improved usability and outcomes." }
+  ],
+  "projects": [
+    { "title": "AutoResume CLI", "tools": ["Python"], "dates": "Aug 2025 – Present", "summary": "Command-line tool to generate resume PDFs; added tests and CI." }
+  ],
+  "extracurriculars": [
+    { "title": "HiTECH Club", "dates": "Nov 2021 – Aug 2022", "summary": "Co-founded; taught HTML/CSS; increased test coverage." }
+  ]
+}

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,19 +1,37 @@
-import argparse, json
+"""CLI to generate a resume PDF from JSON input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
 from builder import build_resume
 from pdf_generator import generate_pdf
 
-def main():
-    p = argparse.ArgumentParser(description="Generate resume PDF from JSON")
-    p.add_argument("--input", required=True, help="Path to raw JSON data")
-    p.add_argument("--output", required=True, help="Output PDF path")
-    args = p.parse_args()
+logger = logging.getLogger(__name__)
 
-    with open(args.input, "r", encoding="utf-8") as f:
-        raw = json.load(f)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate resume PDF from JSON")
+    parser.add_argument("--input", required=True, help="Path to raw JSON data")
+    parser.add_argument("--output", required=True, help="Output PDF path")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    with input_path.open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
 
     resume = build_resume(raw)
-    generate_pdf(resume, args.output)
-    print(f"✅ Wrote {args.output}")
+    # If generate_pdf expects a string path, cast to str for safety.
+    generate_pdf(resume, str(output_path))
+
+    logger.info("Wrote %s", output_path)
+
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,19 @@
+import argparse, json
+from builder import build_resume
+from pdf_generator import generate_pdf
+
+def main():
+    p = argparse.ArgumentParser(description="Generate resume PDF from JSON")
+    p.add_argument("--input", required=True, help="Path to raw JSON data")
+    p.add_argument("--output", required=True, help="Output PDF path")
+    args = p.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    resume = build_resume(raw)
+    generate_pdf(resume, args.output)
+    print(f"✅ Wrote {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,8 +7,8 @@ import json
 import logging
 from pathlib import Path
 
-from builder import build_resume
-from pdf_generator import generate_pdf
+from src.builder import build_resume
+from src.pdf_generator import generate_pdf
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
A Basic Summary:

Add a lean runtime Docker image for the CLI (JSON ➜ PDF) and a GitHub Actions workflow that builds and pushes the image to GHCR on pushes to `main`. Keeps dev/test tools out of production.

## What changed
- Added `Dockerfile.runtime` (Python 3.11 slim; installs reportlab + nltk; preloads NLTK `punkt`)
- Added `src/cli.py` (reads JSON, calls `build_resume`, writes PDF)
- Added `sample_data/minimal.json` for demo/testing the CLI
- Added `.github/workflows/docker.yml` to build on PRs and build+push on `main`
- Added `.dockerignore` to speed builds
- Ensured `requirements.txt` includes:
  - `reportlab>=3.6`
  - `nltk>=3.9`

## How to test locally
```bash
# Build runtime image
docker build -f Dockerfile.runtime -t autoresume:dev .

# Generate a PDF from sample data
docker run --rm -v "$PWD":/work -w /work autoresume:dev \
  python -m src.cli --input sample_data/minimal.json --output AutoResume.pdf